### PR TITLE
Changed jsx flag to react and resolved type error

### DIFF
--- a/index.ios.tsx
+++ b/index.ios.tsx
@@ -1,25 +1,21 @@
-import React from "react";
-import {
-  requireNativeComponent,
-  StyleProp,
-  ViewStyle,
-} from "react-native";
+import React from 'react';
+import { requireNativeComponent, StyleProp, ViewStyle } from 'react-native';
 
 export enum SFSymbolWeight {
-  ULTRALIGHT = "ultralight",
-  LIGHT = "light",
-  THIN = "thin",
-  REGULAR = "regular",
-  MEDIUM = "medium",
-  SEMIBOLD = "semibold",
-  BOLD = "bold",
-  HEAVY = "heavy",
+  ULTRALIGHT = 'ultralight',
+  LIGHT = 'light',
+  THIN = 'thin',
+  REGULAR = 'regular',
+  MEDIUM = 'medium',
+  SEMIBOLD = 'semibold',
+  BOLD = 'bold',
+  HEAVY = 'heavy',
 }
 
 export enum SFSymbolScale {
-  SMALL = "small",
-  MEDIUM = "medium",
-  LARGE = "large",
+  SMALL = 'small',
+  MEDIUM = 'medium',
+  LARGE = 'large',
 }
 
 interface SFSymbolProps {
@@ -31,18 +27,16 @@ interface SFSymbolProps {
   multicolor?: boolean;
 }
 
-type NativeSFSymbolProps = Omit<SFSymbolProps, "color" | "name"> & {
-  color: number | symbol;
+type NativeSFSymbolProps = Omit<SFSymbolProps, 'color' | 'name'> & {
+  color: string | symbol;
   systemName: string;
 };
 
-const RNSFSymbol = requireNativeComponent<NativeSFSymbolProps>("RNSfsymbols");
+const RNSFSymbol = requireNativeComponent<NativeSFSymbolProps>('RNSfsymbols');
 
 export class SFSymbol extends React.Component<SFSymbolProps> {
   render() {
     const { name, color, ...props } = this.props;
-    return (
-      <RNSFSymbol {...props} systemName={name} color={color} />
-    );
+    return <RNSFSymbol {...props} systemName={name} color={color} />;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "jsx": "react-native",
+    "jsx": "react",
     "module": "commonjs",
     "declaration": true,
     "esModuleInterop": true,
@@ -12,7 +12,6 @@
     "outDir": "lib"
   },
   "exclude": ["node_modules", "lib"],
-  "include": ["src"],
   "compileOnSave": false,
   "buildOnSave": false
 }


### PR DESCRIPTION
Proposing these changes to help resolve #2:

1. Changed the `"jsx"` flag from `"react-native"` to `"react"` in` tsconfig.json`. It can't compile the jsx correctly when its react-native (more info here https://www.typescriptlang.org/docs/handbook/jsx.html)
2. Removed the `"include"` flag  in` tsconfig.json` as there is no more `src` directory.
3. I wasn't able to compile the ts locally due to a type error in the `NativeSFSymbolProps` type. The `color` prop was originally set to be `number | symbol,` shouldn't this be `string | symbol`? 