### PR TITLE
fix: correct typescript typings path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.3",
   "description": "Use SF Symbols in iOS apps",
   "main": "lib/index.ios.js",
-  "typings": "lib/index.d.ts",
+  "typings": "lib/index.ios.d.ts",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
Currently VSCode can't find the typings because of the missing ".ios" in the `typings` path in `package.json`.

This PR fixes that.