### PR TITLE
fix: `React` doesn't exist.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
-    "jsx": "react-native",
+    "jsx": "react-jsx",
     "lib": ["ESNext"],
     "module": "CommonJS",
     "noEmitOnError": true,
@@ -10,7 +10,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "ESNext",
+    "target": "ESNext"
   },
   "exclude": ["**/__tests__/*"],
   "include": ["src"]


### PR DESCRIPTION
This PR should fix #15.

Not sure why your published version of 1.2.0 has index.ios.js but my local debugging generates none, but anyway, this should fix the output. I've published this fork as a package on npm: `@laosb/react-native-sfsymbols` so you (or those hitting this problem) can verify it's working.