### PR TITLE
Remove old style conditional imports

### DIFF
--- a/ios/RNSfsymbols.h
+++ b/ios/RNSfsymbols.h
@@ -1,9 +1,4 @@
-
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
 
 @interface RNSfsymbols : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
Old style conditional imports no longer work -- they produce "duplicate interface definition" errors when building.  

Using the `#import <React/*>` style import correctly handles the conditioning now.

See https://github.com/ammarahm-ed/react-native-mmkv-storage/pull/259 as an example