### PR TITLE
Fix iOS clang module import for Expo SDK 44

### DIFF
--- a/ios/RNSfsymbols.h
+++ b/ios/RNSfsymbols.h
@@ -1,9 +1,4 @@
-
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
 
 @interface RNSfsymbols : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
from https://github.com/expo/expo/issues/15622#issuecomment-997225774, the double-quoted react header imports will break building on Expo SDK 44. The double-quoted imports should be for react-native < 0.40. as nowadays react-native uses CocoaPods, it should be safe to use the angle-bracket import.