### PR TITLE
feat: add visionOS support

### DIFF
--- a/react-native-sfsymbols.podspec
+++ b/react-native-sfsymbols.podspec
@@ -9,12 +9,12 @@ Pod::Spec.new do |s|
   s.summary               = package["description"]
   s.authors               = package["author"]
   s.homepage              = package["homepage"]
-  
-  s.platforms             = { :ios => "10.0", :tvos => "10.0" }
-  
+
+  s.platforms             = { :ios => "10.0", :tvos => "10.0", :visionos => "1.0" }
+
   s.source                = { :git => package["repository"]["url"], :tag => "v#{s.version}" }
   s.source_files          = "ios/*.{h,m}"
   s.requires_arc = true
-  
+
   s.dependency "React"
 end


### PR DESCRIPTION
Add support for [React Native visionOS](https://github.com/callstack/react-native-visionos), the new out-of-tree platform.

This only adds a new platform to the podspec, so the module can be installed in visionOS. No changes to any existing functionality.

![simulator_screenshot_4A68AA5E-E6CB-4835-A597-0F4DB845419E](https://github.com/birkir/react-native-sfsymbols/assets/26878038/4e12438f-7f1c-42e6-b953-44b2f18d24de)
